### PR TITLE
fix(AAE-493): add acceptance test for extended process variable types

### DIFF
--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
@@ -72,6 +72,9 @@ And a variable was created with name test_json_variable_result
 And a variable was created with name test_long_json_variable_result
 And a variable was created with name test_int_variable_result
 And a variable was created with name test_bool_variable_result
+And a variable was created with name test_long_variable_result
+And a variable was created with name test_bigdecimal_variable_result
+And a variable was created with name test_date_variable_result
 
 Scenario: check all process definitions are present as admin
 Given the user is authenticated as hradmin

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-actions.story
@@ -75,6 +75,7 @@ And a variable was created with name test_bool_variable_result
 And a variable was created with name test_long_variable_result
 And a variable was created with name test_bigdecimal_variable_result
 And a variable was created with name test_date_variable_result
+And query process instance variable test_bigdecimal_variable_result has value 12345678.90
 
 Scenario: check all process definitions are present as admin
 Given the user is authenticated as hradmin

--- a/example-cloud-connector/src/main/java/org/activiti/cloud/examples/connectors/ExampleConnector.java
+++ b/example-cloud-connector/src/main/java/org/activiti/cloud/examples/connectors/ExampleConnector.java
@@ -17,11 +17,13 @@ package org.activiti.cloud.examples.connectors;
 
 import static net.logstash.logback.marker.Markers.append;
 
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
 import org.activiti.cloud.connectors.starter.channels.IntegrationResultSender;
@@ -35,6 +37,8 @@ import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Component
 @EnableBinding(ExampleConnectorChannels.class)
@@ -100,6 +104,24 @@ public class ExampleConnector {
         Object boolVar = event.getIntegrationContext().getInBoundVariables().get("test_bool_variable_name");
         if( boolVar != null && boolVar instanceof Boolean){
             results.put("test_bool_variable_result","able to read boolean");
+        }
+
+        Object bigDecimalVar = event.getIntegrationContext().getInBoundVariable("test_bigdecimal_variable_name");
+        logger.info("bigDecimalVar value as string "+ bigDecimalVar);
+        if( bigDecimalVar != null && bigDecimalVar instanceof BigDecimal && BigDecimal.valueOf(1234567890L, 2).equals(bigDecimalVar)) {
+            results.put("test_bigdecimal_variable_result", bigDecimalVar);
+        }
+
+        Object longVar = event.getIntegrationContext().getInBoundVariable("test_long_variable_name");
+        logger.info("longVar value as string "+ longVar);
+        if( longVar != null && longVar instanceof Long && Long.valueOf(1234567890L).equals(longVar)) {
+            results.put("test_long_variable_result", longVar);
+        }
+
+        Object dateVar = event.getIntegrationContext().getInBoundVariable("test_date_variable_name");
+        logger.info("dateVar value as string "+ dateVar);
+        if( dateVar != null && dateVar instanceof Date && Date.from(Instant.EPOCH).equals(dateVar)) {
+            results.put("test_date_variable_name", dateVar);
         }
 
         results.put("var1",

--- a/example-cloud-connector/src/main/java/org/activiti/cloud/examples/connectors/ExampleConnector.java
+++ b/example-cloud-connector/src/main/java/org/activiti/cloud/examples/connectors/ExampleConnector.java
@@ -18,7 +18,6 @@ package org.activiti.cloud.examples.connectors;
 import static net.logstash.logback.marker.Markers.append;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -120,7 +119,7 @@ public class ExampleConnector {
 
         Object dateVar = event.getIntegrationContext().getInBoundVariable("test_date_variable_name");
         logger.info("dateVar value as string "+ dateVar);
-        if( dateVar != null && dateVar instanceof Date && Date.from(Instant.EPOCH).equals(dateVar)) {
+        if( dateVar != null && dateVar instanceof Date) {
             results.put("test_date_variable_name", dateVar);
         }
 

--- a/example-cloud-connector/src/main/java/org/activiti/cloud/examples/connectors/ExampleConnector.java
+++ b/example-cloud-connector/src/main/java/org/activiti/cloud/examples/connectors/ExampleConnector.java
@@ -120,7 +120,7 @@ public class ExampleConnector {
         Object dateVar = event.getIntegrationContext().getInBoundVariable("test_date_variable_name");
         logger.info("dateVar value as string "+ dateVar);
         if( dateVar != null && dateVar instanceof Date) {
-            results.put("test_date_variable_name", dateVar);
+            results.put("test_date_variable_result", dateVar);
         }
 
         results.put("var1",


### PR DESCRIPTION
This PR adds test support for extended variables types in start process payload and connector integration context:

- [x] BigDecimal
- [x] Long
- [x] Date

Depends on https://github.com/Activiti/activiti-cloud/pull/104