### PR TITLE
Keep default default configuration for Jackson date format

### DIFF
--- a/activiti-cloud-acceptance-scenarios/modeling-acceptance-tests/src/main/resources/config-env.properties
+++ b/activiti-cloud-acceptance-scenarios/modeling-acceptance-tests/src/main/resources/config-env.properties
@@ -4,4 +4,3 @@ auth.url=${sso.url}/realms/${realm}/protocol/openid-connect/token
 gateway.url=${gateway.protocol:http}://${gateway.host}
 modeling.url=${gateway.url}/${modeling.path}
 modeling.path=modeling-service
-spring.jackson.date-format=yyyy-MM-dd'T'HH:mm:ss.SSSZ

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/config-env.properties
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/config-env.properties
@@ -8,4 +8,3 @@ query.url=${gateway.url}/query
 graphql.ws.url=#{"${gateway.url}".replace('http', 'ws')}/notifications/ws/graphql
 graphql.url=${gateway.url}/notifications/graphql
 runtime.bundle.service.name=rb
-spring.jackson.date-format=yyyy-MM-dd'T'HH:mm:ss.SSSZ

--- a/activiti-cloud-modeling/src/main/resources/application.properties
+++ b/activiti-cloud-modeling/src/main/resources/application.properties
@@ -25,7 +25,3 @@ spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.change-log=classpath:config/modeling/liquibase/master.xml
 spring.liquibase.database-change-log-table=DATABASECHANGELOG_ORG_SERVICE
 spring.liquibase.database-change-log-lock-table=DATABASECHANGELOGLOCK_ORG_SERVICE
-
-spring.jackson.date-format=yyyy-MM-dd'T'HH:mm:ss.SSSZ
-server.error.include-message=always
-server.error.include-binding-errors=always

--- a/activiti-cloud-query/src/main/resources/application.properties
+++ b/activiti-cloud-query/src/main/resources/application.properties
@@ -57,6 +57,3 @@ spring.audit.liquibase.database-change-log-lock-table=DATABASECHANGELOGLOCK_AUDI
 spring.query.liquibase.change-log=classpath:config/query/liquibase/master.xml
 spring.query.liquibase.database-change-log-table=DATABASECHANGELOG_QUERY
 spring.query.liquibase.database-change-log-lock-table=DATABASECHANGELOGLOCK_QUERY
-
-spring.jackson.date-format=yyyy-MM-dd'T'HH:mm:ss.SSSZ
-server.error.include-message=always

--- a/example-cloud-connector/src/main/resources/application.properties
+++ b/example-cloud-connector/src/main/resources/application.properties
@@ -55,6 +55,3 @@ spring.zipkin.enabled=false
 spring.zipkin.base-url=http://zipkin:80/
 spring.zipkin.sender.type=web
 spring.sleuth.sampler.probability=1.0
-
-spring.jackson.date-format=yyyy-MM-dd'T'HH:mm:ss.SSSZ
-server.error.include-message=always

--- a/example-runtime-bundle/src/main/resources/application.properties
+++ b/example-runtime-bundle/src/main/resources/application.properties
@@ -46,6 +46,3 @@ activiti.cloud.application.name=default-app
 
 # project manifest path
 project.manifest.file.path=classpath:/default-project.json
-
-spring.jackson.date-format=yyyy-MM-dd'T'HH:mm:ss.SSSZ
-server.error.include-message=always


### PR DESCRIPTION
When the property `spring.jackson.date-format` is set to `yyyy-MM-dd'T'HH:mm:ss.SSSZ` the format `2020-06-22T15:26:50.936Z` is no longer accepted, but only `2020-06-22T15:26:50.936+0000`

Ref https://github.com/Activiti/Activiti/issues/3352