### PR TITLE
feat(AAE-3195): Add acceptance test for REST API to list Service Tasks

### DIFF
--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helpers/ProcessDefinitionRegistry.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/helpers/ProcessDefinitionRegistry.java
@@ -81,6 +81,8 @@ public class ProcessDefinitionRegistry {
             "errorStartEventSubProcess");
         put("ERROR_BOUNDARY_EVENT_CALLACTIVITY",
             "catchErrorOnCallActivity");
+        put("BPMN_ERROR_CONNECTOR_PROCESS",
+            "testBpmnErrorConnectorProcess");
     }};
 
     public static final HashMap<String, String> processDefinitionKeys = new HashMap<String, String>() {{

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.events.IntegrationEvent;
-import org.activiti.api.task.model.Task;
 import org.activiti.cloud.acc.core.steps.audit.AuditSteps;
 import org.activiti.cloud.acc.core.steps.query.ProcessQuerySteps;
 import org.activiti.cloud.acc.core.steps.query.admin.ProcessQueryAdminSteps;
@@ -35,7 +34,6 @@ import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.CloudBPMNActivity;
 import org.activiti.cloud.api.process.model.CloudIntegrationContext;
 import org.activiti.cloud.api.process.model.events.CloudIntegrationEvent;
-import org.activiti.cloud.api.task.model.CloudTask;
 import org.jbehave.core.annotations.Then;
 import org.jbehave.core.annotations.When;
 import org.springframework.hateoas.PagedModel;
@@ -70,26 +68,6 @@ public class ProcessInstanceServiceTasks {
     public void startProcess(String processName) throws IOException, InterruptedException {
         processInstance = processRuntimeBundleSteps.startProcess(processDefinitionKeyMatcher(processName),false);
         Serenity.setSessionVariable("processInstanceId").to(processInstance.getId());
-    }
-
-    @Then("the user can see a service tasks with a status $status")
-    public void verifyServiceTaskWithStatusFromProcessInstance(String taskName,
-                                              Task.TaskStatus status) {
-
-        String processId = Serenity.sessionVariableCalled("processInstanceId");
-
-        await().untilAsserted(() -> {
-            Collection<CloudTask> tasks = processRuntimeBundleSteps.getTaskByProcessInstanceId(processId);
-
-            assertThat(tasks)
-            .isNotEmpty()
-            .extracting("status",
-                        "name")
-            .containsExactly(
-                              tuple(status,
-                                    taskName
-                              ));
-        });
     }
 
     @Then("the user deletes the process with service tasks")

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
@@ -161,8 +161,12 @@ public class ProcessInstanceServiceTasks {
         await().untilAsserted(() -> {
             PagedModel<CloudBPMNActivity> tasks = processQueryAdminSteps.getServiceTasksByQuery(queryMap);
             assertThat(tasks.getContent()).isNotEmpty()
-                                          .extracting(CloudBPMNActivity::getActivityType, CloudBPMNActivity::getStatus)
-                                          .containsOnly(tuple("serviceTask", CloudBPMNActivity.BPMNActivityStatus.valueOf(status)));
+                                          .extracting(this::getProcessDefinitionKey,
+                                                      CloudBPMNActivity::getActivityType,
+                                                      CloudBPMNActivity::getStatus)
+                                          .containsOnly(tuple(processDefinitionKey,
+                                                              "serviceTask",
+                                                              CloudBPMNActivity.BPMNActivityStatus.valueOf(status)));
         });
     }
 
@@ -255,4 +259,9 @@ public class ProcessInstanceServiceTasks {
     private IntegrationContext integrationContext(CloudRuntimeEvent<?,?> event) {
         return CloudIntegrationEvent.class.cast(event).getEntity();
     }
+
+    private String getProcessDefinitionKey(CloudBPMNActivity bpmnActivity) {
+        return bpmnActivity.getProcessDefinitionId().split(":")[0];
+    }
+
 }

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.cloud.qa.story;
+
+import static org.activiti.api.process.model.events.BPMNErrorReceivedEvent.ErrorEvents.ERROR_RECEIVED;
+import static org.activiti.cloud.qa.helpers.ProcessDefinitionRegistry.processDefinitionKeyMatcher;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.api.task.model.Task;
+import org.activiti.cloud.acc.core.steps.audit.AuditSteps;
+import org.activiti.cloud.acc.core.steps.query.ProcessQuerySteps;
+import org.activiti.cloud.acc.core.steps.runtime.ProcessRuntimeBundleSteps;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.events.CloudIntegrationEvent;
+import org.activiti.cloud.api.task.model.CloudTask;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+
+import net.serenitybdd.core.Serenity;
+import net.thucydides.core.annotations.Steps;
+
+public class ProcessInstanceServiceTasks {
+
+    @Steps
+    private ProcessRuntimeBundleSteps processRuntimeBundleSteps;
+
+    @Steps
+    private ProcessQuerySteps processQuerySteps;
+
+    @Steps
+    private AuditSteps auditSteps;
+
+    private ProcessInstance processInstance;
+
+    @When("services are started")
+    public void checkServicesStatus() {
+        processRuntimeBundleSteps.checkServicesHealth();
+        processQuerySteps.checkServicesHealth();
+        auditSteps.checkServicesHealth();
+    }
+
+    @When("the user starts a process with service tasks called $processName")
+    public void startProcess(String processName) throws IOException, InterruptedException {
+        processInstance = processRuntimeBundleSteps.startProcess(processDefinitionKeyMatcher(processName),false);
+        Serenity.setSessionVariable("processInstanceId").to(processInstance.getId());
+    }
+
+    @Then("the user can see a service tasks with a status $status")
+    public void verifyServiceTaskWithStatusFromProcessInstance(String taskName,
+                                              Task.TaskStatus status) {
+
+        String processId = Serenity.sessionVariableCalled("processInstanceId");
+
+        await().untilAsserted(() -> {
+            Collection<CloudTask> tasks = processRuntimeBundleSteps.getTaskByProcessInstanceId(processId);
+
+            assertThat(tasks)
+            .isNotEmpty()
+            .extracting("status",
+                        "name")
+            .containsExactly(
+                              tuple(status,
+                                    taskName
+                              ));
+        });
+    }
+
+    @Then("the user deletes the process with service tasks")
+    public void deleteCurrentProcessInstance() throws Exception {
+        String processId = Serenity.sessionVariableCalled("processInstanceId");
+        processRuntimeBundleSteps.deleteProcessInstance(processId);
+    }
+
+    @Then("the process with service tasks is completed")
+    public void verifyProcessCompleted() throws Exception {
+        String processId = Serenity.sessionVariableCalled("processInstanceId");
+        processQuerySteps.checkProcessInstanceStatus(processId,
+                ProcessInstance.ProcessInstanceStatus.COMPLETED);
+    }
+
+    @Then("integration context events are emitted for the process")
+    public void verifyIntegrationContextEventsForProcess() throws Exception {
+
+        String processId = Serenity.sessionVariableCalled("processInstanceId");
+
+        await().untilAsserted(() -> {
+            Collection<CloudRuntimeEvent> events = auditSteps.getEventsByProcessInstanceId(processId);
+
+            assertThat(events)
+                    .filteredOn(CloudIntegrationEvent.class::isInstance)
+                    .isNotEmpty()
+                    .extracting(CloudRuntimeEvent::getEventType,
+                                CloudRuntimeEvent::getProcessDefinitionId,
+                                CloudRuntimeEvent::getProcessInstanceId,
+                                CloudRuntimeEvent::getProcessDefinitionKey,
+                                CloudRuntimeEvent::getBusinessKey,
+                                event -> integrationContext(event).getProcessDefinitionId(),
+                                event -> integrationContext(event).getProcessInstanceId()
+                    )
+                    .containsExactly(
+                                     tuple(ERROR_RECEIVED,
+                                           processInstance.getProcessDefinitionId(),
+                                           processInstance.getId(),
+                                           processInstance.getProcessDefinitionKey(),
+                                           processInstance.getBusinessKey(),
+                                           processInstance.getProcessDefinitionId(),
+                                           processInstance.getId()
+                                     ));
+        });
+    }
+
+    private IntegrationContext integrationContext(CloudRuntimeEvent<?,?> event) {
+        return CloudIntegrationEvent.class.cast(event).getEntity();
+    }
+}

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
@@ -17,11 +17,13 @@ package org.activiti.cloud.qa.story;
 
 import static org.activiti.cloud.qa.helpers.ProcessDefinitionRegistry.processDefinitionKeyMatcher;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.ProcessInstance;
@@ -150,13 +152,17 @@ public class ProcessInstanceServiceTasks {
         });
     }
 
-    @Then("the user can get list of service tasks by query of $query")
-    public void verifyGetServiceTaskByQuery(String query) {
+    @Then("the user can get list of service tasks for process key $processDefinitionKey and status $status")
+    public void verifyGetServiceTaskByQuery(String processDefinitionKey,
+                                            String status) {
+        Map<String, String> queryMap = Map.ofEntries(entry("processDefinitionKey", processDefinitionKey),
+                                                     entry("status", status));
+
         await().untilAsserted(() -> {
-            PagedModel<CloudBPMNActivity> tasks = processQueryAdminSteps.getServiceTasksByQuery(query);
+            PagedModel<CloudBPMNActivity> tasks = processQueryAdminSteps.getServiceTasksByQuery(queryMap);
             assertThat(tasks.getContent()).isNotEmpty()
-                                          .extracting(CloudBPMNActivity::getActivityType)
-                                          .containsOnly("serviceTask");
+                                          .extracting(CloudBPMNActivity::getActivityType, CloudBPMNActivity::getStatus)
+                                          .containsOnly(tuple("serviceTask", CloudBPMNActivity.BPMNActivityStatus.valueOf(status)));
         });
     }
 

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
@@ -132,8 +132,8 @@ public class ProcessInstanceServiceTasks {
             CloudIntegrationContext serviceTask = processQueryAdminSteps.getCloudIntegrationContext(serviceTaskId);
 
             assertThat(serviceTask).isNotNull()
-                                   .extracting(CloudIntegrationContext::getClientType)
-                                   .isEqualTo("serviceTask");
+                                   .extracting(CloudIntegrationContext::getClientType, CloudIntegrationContext::getStatus)
+                                   .contains("ServiceTask", CloudIntegrationContext.IntegrationContextStatus.INTEGRATION_RESULT_RECEIVED);
         });
     }
 
@@ -146,7 +146,7 @@ public class ProcessInstanceServiceTasks {
                                                                                                  status);
             assertThat(tasks.getContent()).isNotEmpty()
                                           .extracting(CloudBPMNActivity::getActivityType, CloudBPMNActivity::getStatus)
-                                          .isEqualTo(tuple("serviceTask", CloudBPMNActivity.BPMNActivityStatus.valueOf(status)));
+                                          .contains(tuple("serviceTask", CloudBPMNActivity.BPMNActivityStatus.valueOf(status)));
         });
     }
 

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
@@ -15,7 +15,6 @@
  */
 package org.activiti.cloud.qa.story;
 
-import static org.activiti.api.process.model.events.BPMNErrorReceivedEvent.ErrorEvents.ERROR_RECEIVED;
 import static org.activiti.cloud.qa.helpers.ProcessDefinitionRegistry.processDefinitionKeyMatcher;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -26,6 +25,7 @@ import java.util.Collection;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.api.process.model.events.IntegrationEvent;
 import org.activiti.api.task.model.Task;
 import org.activiti.cloud.acc.core.steps.audit.AuditSteps;
 import org.activiti.cloud.acc.core.steps.query.ProcessQuerySteps;
@@ -118,7 +118,15 @@ public class ProcessInstanceServiceTasks {
                                 event -> integrationContext(event).getProcessInstanceId()
                     )
                     .containsExactly(
-                                     tuple(ERROR_RECEIVED,
+                                     tuple(IntegrationEvent.IntegrationEvents.INTEGRATION_RESULT_RECEIVED,
+                                           processInstance.getProcessDefinitionId(),
+                                           processInstance.getId(),
+                                           processInstance.getProcessDefinitionKey(),
+                                           processInstance.getBusinessKey(),
+                                           processInstance.getProcessDefinitionId(),
+                                           processInstance.getId()
+                                     ),
+                                     tuple(IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED,
                                            processInstance.getProcessDefinitionId(),
                                            processInstance.getId(),
                                            processInstance.getProcessDefinitionKey(),

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -13,7 +13,7 @@ And the process with service tasks completed
 Scenario: get service tasks for process instance 
 Given the user is authenticated as testadmin
 When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
-Then the user can get list of of all service tasks for process instance
+Then the user can get list of service tasks for process instance
 And the process with service tasks completed
 
 Scenario: get service task by id 
@@ -28,8 +28,22 @@ When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTA
 Then the user can get service task integration context by service task id
 And the process with service tasks completed
 
-Scenario: get all service tasks by status 
+Scenario: get service tasks by COMPLETED status for process instance
 Given the user is authenticated as testadmin
 When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
-Then the user can get list of of all service tasks with status of COMPLETED
+Then the user can get list of service tasks with status of COMPLETED
 And the process with service tasks completed
+
+Scenario: get service tasks by ERROR status for process instance
+Given the user is authenticated as testadmin
+And the user provides a variable named var with value test
+When the user starts an instance of process called testBpmnErrorConnectorProcess with the provided variables
+Then cloud bpmn error event is emitted for the process
+And integration context error events are emitted for the process
+And the user can get list of service tasks with status of ERROR
+And the status of the process is changed to cancelled
+
+Scenario: get all service tasks by query 
+Given the user is authenticated as testadmin
+Then the user can get list of service tasks by query of processDefinitionKey=ConnectorProcess&status=COMPLETED
+Then the user can get list of service tasks by query of processDefinitionKey=testBpmnErrorConnectorProcess&status=ERROR

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -37,9 +37,8 @@ And the process with service tasks completed
 Scenario: get service tasks by ERROR status for process instance
 Given the user is authenticated as testadmin
 And the user provides a variable named var with value test
-When the user starts an instance of process called testBpmnErrorConnectorProcess with the provided variables
-Then cloud bpmn error event is emitted for the process
-And integration context error events are emitted for the process
+When the user starts a process with service tasks called BPMN_ERROR_CONNECTOR_PROCESS
+Then integration context error events are emitted for the process
 And the user can get list of service tasks with status of ERROR
 And the status of the process is changed to cancelled
 

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -9,3 +9,27 @@ Given the user is authenticated as testadmin
 When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
 Then integration context events are emitted for the process
 And the process with service tasks completed
+
+Scenario: get service tasks for process instance 
+Given the user is authenticated as testadmin
+When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
+Then the user can get list of of all service tasks for process instance
+And the process with service tasks completed
+
+Scenario: get service task by id 
+Given the user is authenticated as testadmin
+When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
+Then the user can get service task by id
+And the process with service tasks completed
+
+Scenario: get service task integration context by service task id
+Given the user is authenticated as testadmin
+When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
+Then the user can get service task integration context by service task id
+And the process with service tasks completed
+
+Scenario: get all service tasks by status 
+Given the user is authenticated as testadmin
+When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
+Then the user can get list of of all service tasks with status of COMPLETED
+And the process with service tasks completed

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -42,7 +42,12 @@ Then integration context error events are emitted for the process
 And the user can get list of service tasks with status of ERROR
 And the status of the process is changed to cancelled
 
-#Scenario: get all service tasks by query 
-#Given the user is authenticated as testadmin
-#Then the user can get list of service tasks by query of processDefinitionKey=ConnectorProcess&status=COMPLETED
-#Then the user can get list of service tasks by query of processDefinitionKey=testBpmnErrorConnectorProcess&status=ERROR
+Scenario: get all completed service tasks by query 
+Given the user is authenticated as testadmin
+When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
+Then the user can get list of service tasks for process key ConnectorProcess and status COMPLETED
+
+Scenario: get all error service tasks by query 
+Given the user is authenticated as testadmin
+When the user starts a process with service tasks called BPMN_ERROR_CONNECTOR_PROCESS
+Then the user can get list of service tasks for process key testBpmnErrorConnectorProcess and status ERROR

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -4,9 +4,8 @@ Narrative:
 As a user
 I want to perform operations on process instance having service tasks
 
-Scenario: get a list of all service tasks for process instance 
+Scenario: audit service tasks integration context events for process instance 
 Given the user is authenticated as testadmin
 When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
 Then integration context events are emitted for the process
-And the user can query list of of all service task for process instance
 And the process with service tasks completed

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -1,0 +1,12 @@
+Meta:
+
+Narrative:
+As a user
+I want to perform operations on process instance having service tasks
+
+Scenario: get a list of all service tasks for process instance 
+Given the user is authenticated as testadmin
+When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
+Then integration context events are emitted for the process
+And the user can query list of of all service task for process instance
+And the process with service tasks completed

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -42,7 +42,7 @@ Then integration context error events are emitted for the process
 And the user can get list of service tasks with status of ERROR
 And the status of the process is changed to cancelled
 
-Scenario: get all service tasks by query 
-Given the user is authenticated as testadmin
-Then the user can get list of service tasks by query of processDefinitionKey=ConnectorProcess&status=COMPLETED
-Then the user can get list of service tasks by query of processDefinitionKey=testBpmnErrorConnectorProcess&status=ERROR
+#Scenario: get all service tasks by query 
+#Given the user is authenticated as testadmin
+#Then the user can get list of service tasks by query of processDefinitionKey=ConnectorProcess&status=COMPLETED
+#Then the user can get list of service tasks by query of processDefinitionKey=testBpmnErrorConnectorProcess&status=ERROR


### PR DESCRIPTION
This PR adds acceptance test for REST API to list Service Tasks:

- [x] audit service tasks integration context events for process instance 
- [x] get service tasks for process instance 
- [x] get service task by id 
- [x] get service task integration context by service task id
- [x] get service tasks by query, i.e processDefintionKey and  status, i.e. COMPLETED, ERROR

Depends on https://github.com/Activiti/activiti-cloud/pull/209

Part of https://github.com/Activiti/Activiti/issues/3426, https://github.com/Activiti/Activiti/issues/3427