### PR TITLE
Improve logic while waiting for services to be up 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_script:
 - kubectl get ns || travis_terminate 1
 stages:
 - name: build
+- name: run acceptance tests
 - name: tag_updatebot
   if: type != pull_request
 install: true
@@ -58,6 +59,7 @@ jobs:
       VERSION) example-runtime-bundle
     - docker build -f activiti-cloud-modeling/Dockerfile -q -t docker.io/activiti/activiti-cloud-modeling:$(cat
       VERSION) activiti-cloud-modeling
+    - make create-helm-charts-release-and-upload
     - docker push docker.io/activiti/activiti-cloud-query:$(cat VERSION) || travis_terminate
       1
     - docker push docker.io/activiti/example-runtime-bundle:$(cat VERSION) || travis_terminate
@@ -66,7 +68,6 @@ jobs:
       1
     - docker push docker.io/activiti/activiti-cloud-modeling:$(cat VERSION) || travis_terminate
       1
-    - make create-helm-charts-release-and-upload
     - cp VERSION  activiti-cloud-dependencies/
     - cd activiti-cloud-dependencies
     - travis_wait ${TRAVIS_WAIT_TIMEOUT} mvn -q versions:set -Droot.log.level=off
@@ -75,12 +76,48 @@ jobs:
     - sleep 20
     - make prepare-helm-chart || travis_terminate 1
     - make run-helm-chart || travis_terminate 1
-    - cd -
-    - sleep 240
-    - cd activiti-cloud-acceptance-scenarios
-    - mvn -pl 'modeling-acceptance-tests' -Droot.log.level=off -q clean verify
-    - mvn -pl 'runtime-acceptance-tests'  -Droot.log.level=off -q clean verify
-    - cd -
+
+  - stage: run acceptance tests
+    name: run modeling acceptance tests
+    script: |
+      attempt_counter=0
+      max_attempts=50
+      echo "Waiting for services to be up..."
+      until $(curl --output /dev/null --silent --head --fail \
+                ${GATEWAY_HOST}/modeling-service/v2/api-docs); do
+          if [ ${attempt_counter} -eq ${max_attempts} ];then
+            echo "Max attempts reached"
+            break
+          fi
+
+          printf '.'
+          attempt_counter=$((attempt_counter+1))
+          sleep 5
+      done
+      cd activiti-cloud-acceptance-scenarios
+      mvn -pl 'modeling-acceptance-tests' -Droot.log.level=off -q clean verify
+
+  - name: run runtime acceptance tests
+    script: |
+      attempt_counter=0
+      max_attempts=50
+      echo "Waiting for services to be up..."
+      until $(curl --output /dev/null --silent --head --fail \
+                ${GATEWAY_HOST}/rb/v2/api-docs) &&
+            $(curl --output /dev/null --silent --head --fail \
+            ${GATEWAY_HOST}/query/v2/api-docs); do
+          if [ ${attempt_counter} -eq ${max_attempts} ];then
+            echo "Max attempts reached"
+            break
+          fi
+
+          printf '.'
+          attempt_counter=$((attempt_counter+1))
+          sleep 5
+      done
+      cd activiti-cloud-acceptance-scenarios
+      mvn -pl 'runtime-acceptance-tests'  -Droot.log.level=off -q clean verify
+
   - name: tag_updatebot
     stage: tag_updatebot
     script: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,16 @@ jobs:
       travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f example-cloud-connector/pom.xml
       travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-modeling/pom.xml
       travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-dependencies/pom.xml
+      echo "Building docker image for activiti-cloud-query..."
       docker build -f activiti-cloud-query/Dockerfile -q -t docker.io/activiti/activiti-cloud-query:$(cat
       VERSION) activiti-cloud-query
+      echo "Building docker image for activiti-cloud-connector..."
       docker build -f example-cloud-connector/Dockerfile -q -t docker.io/activiti/example-cloud-connector:$(cat
       VERSION) example-cloud-connector
+      echo "Building docker image for example-runtime-bundle..."
       docker build -f example-runtime-bundle/Dockerfile -q -t docker.io/activiti/example-runtime-bundle:$(cat
       VERSION) example-runtime-bundle
+      echo "Building docker image for activiti-cloud-modeling..."
       docker build -f activiti-cloud-modeling/Dockerfile -q -t docker.io/activiti/activiti-cloud-modeling:$(cat
       VERSION) activiti-cloud-modeling
       make create-helm-charts-release-and-upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,11 @@ jobs:
       max_attempts=50
       echo "Waiting for services to be up..."
       until curl --silent --head --fail \
-                ${GATEWAY_HOST}/modeling-service/v2/api-docs > /dev/null &&
+                ${GATEWAY_HOST}/modeling-service/v2/api-docs > /dev/null 2>&1 &&
             curl --silent --head --fail \
-                 ${GATEWAY_HOST}/rb/v2/api-docs > /dev/null &&
+                 ${GATEWAY_HOST}/rb/v2/api-docs > /dev/null 2>&1 &&
              curl --silent --head --fail \
-                  ${GATEWAY_HOST}/query/v2/api-docs > /dev/null; do
+                  ${GATEWAY_HOST}/query/v2/api-docs > /dev/null 2>&1; do
           if [ ${attempt_counter} -eq ${max_attempts} ];then
             echo "Max attempts reached"
             break

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,12 +69,12 @@ jobs:
       attempt_counter=0
       max_attempts=50
       echo "Waiting for services to be up..."
-      until $(curl --output /dev/null --silent --head --fail \
-                ${GATEWAY_HOST}/modeling-service/v2/api-docs) &&
-            $(curl --output /dev/null --silent --head --fail \
-                 ${GATEWAY_HOST}/rb/v2/api-docs) &&
-             $(curl --output /dev/null --silent --head --fail \
-                  ${GATEWAY_HOST}/query/v2/api-docs); do
+      until curl --silent --head --fail \
+                ${GATEWAY_HOST}/modeling-service/v2/api-docs > /dev/null &&
+            curl --silent --head --fail \
+                 ${GATEWAY_HOST}/rb/v2/api-docs > /dev/null &&
+             curl --silent --head --fail \
+                  ${GATEWAY_HOST}/query/v2/api-docs > /dev/null; do
           if [ ${attempt_counter} -eq ${max_attempts} ];then
             echo "Max attempts reached"
             break

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
       sleep 20
       make prepare-helm-chart
       make run-helm-chart
-      cd-
+      cd -
 
       attempt_counter=0
       max_attempts=50

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_script:
 - kubectl get ns || travis_terminate 1
 stages:
 - name: build
-- name: run acceptance tests
 - name: tag_updatebot
   if: type != pull_request
 install: true
@@ -38,53 +37,44 @@ jobs:
   include:
   - name: build jars
     stage: build
-    script:
-    - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -DskipITs -DskipTests -f activiti-cloud-acceptance-scenarios/pom.xml
-      || travis_terminate 1
-    - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f example-runtime-bundle/pom.xml
-      || travis_terminate 1
-    - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-query/pom.xml
-      || travis_terminate 1
-    - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f example-cloud-connector/pom.xml
-      || travis_terminate 1
-    - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-modeling/pom.xml
-      || travis_terminate 1
-    - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-dependencies/pom.xml
-      || travis_terminate 1
-    - docker build -f activiti-cloud-query/Dockerfile -q -t docker.io/activiti/activiti-cloud-query:$(cat
-      VERSION) activiti-cloud-query
-    - docker build -f example-cloud-connector/Dockerfile -q -t docker.io/activiti/example-cloud-connector:$(cat
-      VERSION) example-cloud-connector
-    - docker build -f example-runtime-bundle/Dockerfile -q -t docker.io/activiti/example-runtime-bundle:$(cat
-      VERSION) example-runtime-bundle
-    - docker build -f activiti-cloud-modeling/Dockerfile -q -t docker.io/activiti/activiti-cloud-modeling:$(cat
-      VERSION) activiti-cloud-modeling
-    - make create-helm-charts-release-and-upload
-    - docker push docker.io/activiti/activiti-cloud-query:$(cat VERSION) || travis_terminate
-      1
-    - docker push docker.io/activiti/example-runtime-bundle:$(cat VERSION) || travis_terminate
-      1
-    - docker push docker.io/activiti/example-cloud-connector:$(cat VERSION) || travis_terminate
-      1
-    - docker push docker.io/activiti/activiti-cloud-modeling:$(cat VERSION) || travis_terminate
-      1
-    - cp VERSION  activiti-cloud-dependencies/
-    - cd activiti-cloud-dependencies
-    - travis_wait ${TRAVIS_WAIT_TIMEOUT} mvn -q versions:set -Droot.log.level=off
-      -DnewVersion=${VERSION}  || travis_terminate 1
-    - make updatebot/push-version-dry || travis_terminate 1
-    - sleep 20
-    - make prepare-helm-chart || travis_terminate 1
-    - make run-helm-chart || travis_terminate 1
-
-  - stage: run acceptance tests
-    name: run modeling acceptance tests
     script: |
+      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -DskipITs -DskipTests -f activiti-cloud-acceptance-scenarios/pom.xml
+      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f example-runtime-bundle/pom.xml
+      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-query/pom.xml
+      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f example-cloud-connector/pom.xml
+      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-modeling/pom.xml
+      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-dependencies/pom.xml
+      docker build -f activiti-cloud-query/Dockerfile -q -t docker.io/activiti/activiti-cloud-query:$(cat
+      VERSION) activiti-cloud-query
+      docker build -f example-cloud-connector/Dockerfile -q -t docker.io/activiti/example-cloud-connector:$(cat
+      VERSION) example-cloud-connector
+      docker build -f example-runtime-bundle/Dockerfile -q -t docker.io/activiti/example-runtime-bundle:$(cat
+      VERSION) example-runtime-bundle
+      docker build -f activiti-cloud-modeling/Dockerfile -q -t docker.io/activiti/activiti-cloud-modeling:$(cat
+      VERSION) activiti-cloud-modeling
+      make create-helm-charts-release-and-upload
+      docker push docker.io/activiti/activiti-cloud-query:$(cat VERSION)
+      docker push docker.io/activiti/example-runtime-bundle:$(cat VERSION)
+      docker push docker.io/activiti/example-cloud-connector:$(cat VERSION)
+      docker push docker.io/activiti/activiti-cloud-modeling:$(cat VERSION)
+      cp VERSION  activiti-cloud-dependencies/
+      cd activiti-cloud-dependencies
+      travis_wait ${TRAVIS_WAIT_TIMEOUT} mvn -q versions:set -Droot.log.level=off
+      -DnewVersion=${VERSION}
+      make updatebot/push-version-dry
+      sleep 20
+      make prepare-helm-chart
+      make run-helm-chart
+
       attempt_counter=0
       max_attempts=50
       echo "Waiting for services to be up..."
       until $(curl --output /dev/null --silent --head --fail \
-                ${GATEWAY_HOST}/modeling-service/v2/api-docs); do
+                ${GATEWAY_HOST}/modeling-service/v2/api-docs) &&
+            $(curl --output /dev/null --silent --head --fail \
+                 ${GATEWAY_HOST}/rb/v2/api-docs) &&
+             $(curl --output /dev/null --silent --head --fail \
+                  ${GATEWAY_HOST}/query/v2/api-docs); do
           if [ ${attempt_counter} -eq ${max_attempts} ];then
             echo "Max attempts reached"
             break
@@ -96,26 +86,6 @@ jobs:
       done
       cd activiti-cloud-acceptance-scenarios
       mvn -pl 'modeling-acceptance-tests' -Droot.log.level=off -q clean verify
-
-  - name: run runtime acceptance tests
-    script: |
-      attempt_counter=0
-      max_attempts=50
-      echo "Waiting for services to be up..."
-      until $(curl --output /dev/null --silent --head --fail \
-                ${GATEWAY_HOST}/rb/v2/api-docs) &&
-            $(curl --output /dev/null --silent --head --fail \
-            ${GATEWAY_HOST}/query/v2/api-docs); do
-          if [ ${attempt_counter} -eq ${max_attempts} ];then
-            echo "Max attempts reached"
-            break
-          fi
-
-          printf '.'
-          attempt_counter=$((attempt_counter+1))
-          sleep 5
-      done
-      cd activiti-cloud-acceptance-scenarios
       mvn -pl 'runtime-acceptance-tests'  -Droot.log.level=off -q clean verify
 
   - name: tag_updatebot

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,17 +45,13 @@ jobs:
       travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-modeling/pom.xml
       travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-dependencies/pom.xml
       echo "Building docker image for activiti-cloud-query..."
-      docker build -f activiti-cloud-query/Dockerfile -q -t docker.io/activiti/activiti-cloud-query:$(cat
-      VERSION) activiti-cloud-query
+      docker build -f activiti-cloud-query/Dockerfile -t docker.io/activiti/activiti-cloud-query:$(cat VERSION) activiti-cloud-query
       echo "Building docker image for activiti-cloud-connector..."
-      docker build -f example-cloud-connector/Dockerfile -q -t docker.io/activiti/example-cloud-connector:$(cat
-      VERSION) example-cloud-connector
+      docker build -f example-cloud-connector/Dockerfile -t docker.io/activiti/example-cloud-connector:$(cat VERSION) example-cloud-connector
       echo "Building docker image for example-runtime-bundle..."
-      docker build -f example-runtime-bundle/Dockerfile -q -t docker.io/activiti/example-runtime-bundle:$(cat
-      VERSION) example-runtime-bundle
+      docker build -f example-runtime-bundle/Dockerfile -t docker.io/activiti/example-runtime-bundle:$(cat VERSION) example-runtime-bundle
       echo "Building docker image for activiti-cloud-modeling..."
-      docker build -f activiti-cloud-modeling/Dockerfile -q -t docker.io/activiti/activiti-cloud-modeling:$(cat
-      VERSION) activiti-cloud-modeling
+      docker build -f activiti-cloud-modeling/Dockerfile -t docker.io/activiti/activiti-cloud-modeling:$(cat VERSION) activiti-cloud-modeling
       make create-helm-charts-release-and-upload
       docker push docker.io/activiti/activiti-cloud-query:$(cat VERSION)
       docker push docker.io/activiti/example-runtime-bundle:$(cat VERSION)
@@ -63,8 +59,7 @@ jobs:
       docker push docker.io/activiti/activiti-cloud-modeling:$(cat VERSION)
       cp VERSION  activiti-cloud-dependencies/
       cd activiti-cloud-dependencies
-      travis_wait ${TRAVIS_WAIT_TIMEOUT} mvn -q versions:set -Droot.log.level=off
-      -DnewVersion=${VERSION}
+      travis_wait ${TRAVIS_WAIT_TIMEOUT} mvn -q versions:set -Droot.log.level=off -DnewVersion=${VERSION}
       make updatebot/push-version-dry
       sleep 20
       make prepare-helm-chart

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,13 +45,13 @@ jobs:
       travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-modeling/pom.xml
       travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-dependencies/pom.xml
       echo "Building docker image for activiti-cloud-query..."
-      docker build -f activiti-cloud-query/Dockerfile -t docker.io/activiti/activiti-cloud-query:$(cat VERSION) activiti-cloud-query
+      docker build -f activiti-cloud-query/Dockerfile -q -t docker.io/activiti/activiti-cloud-query:$(cat VERSION) activiti-cloud-query
       echo "Building docker image for activiti-cloud-connector..."
-      docker build -f example-cloud-connector/Dockerfile -t docker.io/activiti/example-cloud-connector:$(cat VERSION) example-cloud-connector
+      docker build -f example-cloud-connector/Dockerfile -q -t docker.io/activiti/example-cloud-connector:$(cat VERSION) example-cloud-connector
       echo "Building docker image for example-runtime-bundle..."
-      docker build -f example-runtime-bundle/Dockerfile -t docker.io/activiti/example-runtime-bundle:$(cat VERSION) example-runtime-bundle
+      docker build -f example-runtime-bundle/Dockerfile -q -t docker.io/activiti/example-runtime-bundle:$(cat VERSION) example-runtime-bundle
       echo "Building docker image for activiti-cloud-modeling..."
-      docker build -f activiti-cloud-modeling/Dockerfile -t docker.io/activiti/activiti-cloud-modeling:$(cat VERSION) activiti-cloud-modeling
+      docker build -f activiti-cloud-modeling/Dockerfile -q -t docker.io/activiti/activiti-cloud-modeling:$(cat VERSION) activiti-cloud-modeling
       make create-helm-charts-release-and-upload
       docker push docker.io/activiti/activiti-cloud-query:$(cat VERSION)
       docker push docker.io/activiti/example-runtime-bundle:$(cat VERSION)

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ jobs:
       sleep 20
       make prepare-helm-chart
       make run-helm-chart
+      cd-
 
       attempt_counter=0
       max_attempts=50

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,56 +37,58 @@ jobs:
   include:
   - name: build jars
     stage: build
-    script: |
-      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -DskipITs -DskipTests -f activiti-cloud-acceptance-scenarios/pom.xml
-      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f example-runtime-bundle/pom.xml
-      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-query/pom.xml
-      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f example-cloud-connector/pom.xml
-      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-modeling/pom.xml
-      travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-dependencies/pom.xml
-      echo "Building docker image for activiti-cloud-query..."
-      docker build -f activiti-cloud-query/Dockerfile -q -t docker.io/activiti/activiti-cloud-query:$(cat VERSION) activiti-cloud-query
-      echo "Building docker image for activiti-cloud-connector..."
-      docker build -f example-cloud-connector/Dockerfile -q -t docker.io/activiti/example-cloud-connector:$(cat VERSION) example-cloud-connector
-      echo "Building docker image for example-runtime-bundle..."
-      docker build -f example-runtime-bundle/Dockerfile -q -t docker.io/activiti/example-runtime-bundle:$(cat VERSION) example-runtime-bundle
-      echo "Building docker image for activiti-cloud-modeling..."
-      docker build -f activiti-cloud-modeling/Dockerfile -q -t docker.io/activiti/activiti-cloud-modeling:$(cat VERSION) activiti-cloud-modeling
-      make create-helm-charts-release-and-upload
-      docker push docker.io/activiti/activiti-cloud-query:$(cat VERSION)
-      docker push docker.io/activiti/example-runtime-bundle:$(cat VERSION)
-      docker push docker.io/activiti/example-cloud-connector:$(cat VERSION)
-      docker push docker.io/activiti/activiti-cloud-modeling:$(cat VERSION)
-      cp VERSION  activiti-cloud-dependencies/
-      cd activiti-cloud-dependencies
-      travis_wait ${TRAVIS_WAIT_TIMEOUT} mvn -q versions:set -Droot.log.level=off -DnewVersion=${VERSION}
-      make updatebot/push-version-dry
-      sleep 20
-      make prepare-helm-chart
-      make run-helm-chart
-      cd -
+    script:
+      - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -DskipITs -DskipTests -f activiti-cloud-acceptance-scenarios/pom.xml
+      - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f example-runtime-bundle/pom.xml
+      - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-query/pom.xml
+      - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f example-cloud-connector/pom.xml
+      - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-modeling/pom.xml
+      - travis_wait ${TRAVIS_WAIT_TIMEOUT} ${MAVEN_CMD} -f activiti-cloud-dependencies/pom.xml
+      - echo "Building docker image for activiti-cloud-query..."
+      - docker build -f activiti-cloud-query/Dockerfile -q -t docker.io/activiti/activiti-cloud-query:$(cat VERSION) activiti-cloud-query
+      - echo "Building docker image for activiti-cloud-connector..."
+      - docker build -f example-cloud-connector/Dockerfile -q -t docker.io/activiti/example-cloud-connector:$(cat VERSION) example-cloud-connector
+      - echo "Building docker image for example-runtime-bundle..."
+      - docker build -f example-runtime-bundle/Dockerfile -q -t docker.io/activiti/example-runtime-bundle:$(cat VERSION) example-runtime-bundle
+      - echo "Building docker image for activiti-cloud-modeling..."
+      - docker build -f activiti-cloud-modeling/Dockerfile -q -t docker.io/activiti/activiti-cloud-modeling:$(cat VERSION) activiti-cloud-modeling
+      - make create-helm-charts-release-and-upload
+      - docker push docker.io/activiti/activiti-cloud-query:$(cat VERSION)
+      - docker push docker.io/activiti/example-runtime-bundle:$(cat VERSION)
+      - docker push docker.io/activiti/example-cloud-connector:$(cat VERSION)
+      - docker push docker.io/activiti/activiti-cloud-modeling:$(cat VERSION)
+      - cp VERSION  activiti-cloud-dependencies/
+      - cd activiti-cloud-dependencies
+      - travis_wait ${TRAVIS_WAIT_TIMEOUT} mvn -q versions:set -Droot.log.level=off -DnewVersion=${VERSION}
+      - make updatebot/push-version-dry
+      - sleep 20
+      - make prepare-helm-chart
+      - make run-helm-chart
+      - cd -
 
-      attempt_counter=0
-      max_attempts=50
-      echo "Waiting for services to be up..."
-      until curl --silent --head --fail \
-                ${GATEWAY_HOST}/modeling-service/v2/api-docs > /dev/null 2>&1 &&
-            curl --silent --head --fail \
-                 ${GATEWAY_HOST}/rb/v2/api-docs > /dev/null 2>&1 &&
-             curl --silent --head --fail \
-                  ${GATEWAY_HOST}/query/v2/api-docs > /dev/null 2>&1; do
-          if [ ${attempt_counter} -eq ${max_attempts} ];then
-            echo "Max attempts reached"
-            break
-          fi
+      - |
+        attempt_counter=0
+        max_attempts=50
+        echo "Waiting for services to be up..."
+        until curl --silent --head --fail \
+                  ${GATEWAY_HOST}/modeling-service/v2/api-docs > /dev/null 2>&1 &&
+              curl --silent --head --fail \
+                   ${GATEWAY_HOST}/rb/v2/api-docs > /dev/null 2>&1 &&
+               curl --silent --head --fail \
+                    ${GATEWAY_HOST}/query/v2/api-docs > /dev/null 2>&1; do
+            if [ ${attempt_counter} -eq ${max_attempts} ];then
+              echo "Max attempts reached"
+              break
+            fi
 
-          printf '.'
-          attempt_counter=$((attempt_counter+1))
-          sleep 5
-      done
-      cd activiti-cloud-acceptance-scenarios
-      mvn -pl 'modeling-acceptance-tests' -Droot.log.level=off -q clean verify
-      mvn -pl 'runtime-acceptance-tests'  -Droot.log.level=off -q clean verify
+            printf '.'
+            attempt_counter=$((attempt_counter+1))
+            sleep 5
+        done
+
+      - cd activiti-cloud-acceptance-scenarios
+      - mvn -pl 'modeling-acceptance-tests' -Droot.log.level=off -q clean verify
+      - mvn -pl 'runtime-acceptance-tests'  -Droot.log.level=off -q clean verify
 
   - name: tag_updatebot
     stage: tag_updatebot


### PR DESCRIPTION
- move helm build before docker push: tentative to avoid intermittent failures due to the chart not being available yet
- check if service is responding instead of sleeping for 240 secondes