### PR TITLE
fix: resolve process with service tasks completed (PENDING)

### DIFF
--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -8,31 +8,31 @@ Scenario: audit service tasks integration context events for process instance
 Given the user is authenticated as testadmin
 When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
 Then integration context events are emitted for the process
-And the process with service tasks completed
+And the process with service tasks is completed
 
 Scenario: get service tasks for process instance 
 Given the user is authenticated as testadmin
 When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
 Then the user can get list of service tasks for process instance
-And the process with service tasks completed
+And the process with service tasks is completed
 
 Scenario: get service task by id 
 Given the user is authenticated as testadmin
 When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
 Then the user can get service task by id
-And the process with service tasks completed
+And the process with service tasks is completed
 
 Scenario: get service task integration context by service task id
 Given the user is authenticated as testadmin
 When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
 Then the user can get service task integration context by service task id
-And the process with service tasks completed
+And the process with service tasks is completed
 
 Scenario: get service tasks by COMPLETED status for process instance
 Given the user is authenticated as testadmin
 When the user starts a process with service tasks called CONNECTOR_PROCESS_INSTANCE
 Then the user can get list of service tasks with status of COMPLETED
-And the process with service tasks completed
+And the process with service tasks is completed
 
 Scenario: get service tasks by ERROR status for process instance
 Given the user is authenticated as testadmin


### PR DESCRIPTION
This PR resolves the process with service tasks completed (PENDING) warning:

```
@Then("the process with service tasks completed")
@Pending
public void thenTheProcessWithServiceTasksCompleted() {
   // PENDING
}
```
