### PR TITLE
Activiti/Activiti#3460 - Added acc tests for applications api

### DIFF
--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ApplicationActions.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ApplicationActions.java
@@ -1,0 +1,72 @@
+package org.activiti.cloud.qa.story;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
+/*
+ * Copyright 2017-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Collection;
+import net.thucydides.core.annotations.Steps;
+import org.activiti.api.process.model.Deployment;
+import org.activiti.api.process.model.events.ApplicationEvent;
+import org.activiti.api.process.model.events.ApplicationEvent.ApplicationEvents;
+import org.activiti.cloud.acc.core.steps.audit.AuditSteps;
+import org.activiti.cloud.acc.core.steps.query.ApplicationQuerySteps;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.CloudApplication;
+import org.activiti.cloud.api.process.model.events.CloudApplicationDeployedEvent;
+import org.jbehave.core.annotations.Then;
+import org.jbehave.core.annotations.When;
+
+public class ApplicationActions {
+
+    @Steps
+    private AuditSteps auditSteps;
+    @Steps
+    private ApplicationQuerySteps applicationQuerySteps;
+
+    @When("services are started")
+    public void checkServicesStatus() {
+        auditSteps.checkServicesHealth();
+        applicationQuerySteps.checkServicesHealth();
+    }
+
+    @Then("application deployed events are emitted on start")
+    public void verifyApplicationDeployedEvents() throws Exception {
+
+        await().untilAsserted(() -> {
+            Collection<CloudRuntimeEvent> events = auditSteps.getEventsByEventType(
+                    ApplicationEvents.APPLICATION_DEPLOYED.name());
+            assertThat(events)
+                    .extracting(CloudRuntimeEvent::getEventType,
+                            event -> deployment(event).getVersion()
+                    ).contains(tuple(ApplicationEvent.ApplicationEvents.APPLICATION_DEPLOYED,
+                    1));
+        });
+    }
+
+    @Then("the user can get applications")
+    public void checkIfApplicationsArePresent(){
+        Collection <CloudApplication> applications = applicationQuerySteps.getAllApplications().getContent();
+        assertThat(applications).isNotEmpty();
+    }
+
+    private Deployment deployment(CloudRuntimeEvent<?, ?> event) {
+        return CloudApplicationDeployedEvent.class.cast(event).getEntity();
+    }
+}

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ApplicationActions.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ApplicationActions.java
@@ -63,7 +63,9 @@ public class ApplicationActions {
     @Then("the user can get applications")
     public void checkIfApplicationsArePresent(){
         Collection <CloudApplication> applications = applicationQuerySteps.getAllApplications().getContent();
-        assertThat(applications).isNotEmpty();
+        assertThat(applications)
+                .extracting(CloudApplication::getName)
+                .containsExactly("default-app");
     }
 
     private Deployment deployment(CloudRuntimeEvent<?, ?> event) {

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/application-action.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/application-action.story
@@ -1,0 +1,14 @@
+Meta:
+
+Narrative:
+As a user
+I want to perform operations on applications
+
+Scenario: application deployed events are saved in audit
+Given the user is authenticated as hruser
+When services are started
+Then application deployed events are emitted on start
+
+Scenario: getting applications
+Given the user is authenticated as hruser
+Then the user can get applications 

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/application-action.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/application-action.story
@@ -11,4 +11,4 @@ Then application deployed events are emitted on start
 
 Scenario: getting applications
 Given the user is authenticated as hruser
-Then the user can get applications 
+Then the user can get applications


### PR DESCRIPTION
Requires [PR #243](https://github.com/Activiti/activiti-cloud/pull/243). Add acc tests for /applications.
I want to check that the integrations between runtime query and audit is successful.
I check if after the start of the services, the  application deployed event is present in the database table.
A new entity should be also created in the application table and If the user call the endpoint he get a record back.