### PR TITLE
fix: Update Travis Helm chart release pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,13 @@ release:
 	sed -i -e "s/version:.*/version: $(VERSION)/" $(ACTIVITI_CLOUD_FULL_EXAMPLE_DIR)/Chart.yaml
 
 	@for CHART in $(CHARTS) ; do \
-		cd $$CHART; \
+		cd $$CHART && \
 		make version && \
 		make build && \
 		make release && \
 		rm $(CURRENT)/$(ACTIVITI_CLOUD_FULL_EXAMPLE_DIR)/charts/$$(basename `pwd`)*.tgz && \
-		cp $$(basename `pwd`)*.tgz $(CURRENT)/$(ACTIVITI_CLOUD_FULL_EXAMPLE_DIR)/charts || exit 1 \
-		cd - ; \
+		cp $$(basename `pwd`)*.tgz $(CURRENT)/$(ACTIVITI_CLOUD_FULL_EXAMPLE_DIR)/charts || exit 1; \
+		cd -; \
 	done
 	
 	cat $(ACTIVITI_CLOUD_FULL_EXAMPLE_DIR)/Chart.yaml

--- a/activiti-cloud-modeling/charts/activiti-cloud-modeling/Makefile
+++ b/activiti-cloud-modeling/charts/activiti-cloud-modeling/Makefile
@@ -47,8 +47,7 @@ github:
 
 version:
 	sed -i -e "s/version:.*/version: $(VERSION)/" Chart.yaml
-	sed -i -e "/frontend:/,/backend:/s/tag: .*/tag: $(VERSION)/" values.yaml
-	sed -i -e "/backend:/,/  resources:/s/tag: .*/tag: $(VERSION)/" values.yaml
+	sed -i '/^.*repository: activiti\/activiti-cloud-modeling/{n;s/tag: .*/tag: $(VERSION)/}' values.yaml
 
 common-helm-chart-version:
 	sed -i -e "s/version:.*/version: $(VERSION)/" requirements.yaml


### PR DESCRIPTION
This PR fixes the following:

- [x] Add missing semi-colon inside Makefile for loop releasing Helm charts
- [x] Update only Modeling backend image tag version with sed, i.e.

```bash
sed -i '/^.*repository: activiti\/activiti-cloud-modeling/{n;s/tag: .*/tag: $(VERSION)/}' values.yaml
```
