### PR TITLE
Remove feign downgrade

### DIFF
--- a/activiti-cloud-acceptance-scenarios/pom.xml
+++ b/activiti-cloud-acceptance-scenarios/pom.xml
@@ -34,32 +34,9 @@
     <maven.compiler.release>${java.release}</maven.compiler.release>
     <activiti-cloud.version>22.2.0-alpha.42</activiti-cloud.version>
     <serenity-maven-plugin.version>2.4.34</serenity-maven-plugin.version>
-    <feign.version>10.7.0</feign.version>
   </properties>
   <dependencyManagement>
     <dependencies>
-      <!--  Override feign version: related to:
-          https://github.com/OpenFeign/feign/issues/942
-          https://github.com/OpenFeign/feign/pull/930
-          sort is not working property in versions previous to 10.2.1
-          sort is broken again from version 10.7.1 (https://github.com/spring-cloud/spring-cloud-openfeign/issues/146#issuecomment-626561502)
-          sort is mapped to `sort=timestamp&sort=desc` instead of `sort=timestamp,desc`
-          -->
-      <dependency>
-        <groupId>io.github.openfeign</groupId>
-        <artifactId>feign-core</artifactId>
-        <version>${feign.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.github.openfeign</groupId>
-        <artifactId>feign-gson</artifactId>
-        <version>${feign.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.github.openfeign</groupId>
-        <artifactId>feign-jackson</artifactId>
-        <version>${feign.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.activiti.cloud</groupId>
         <artifactId>activiti-cloud-acceptance-tests-dependencies</artifactId>


### PR DESCRIPTION
Requires Feign client methods using Pageable to be annotated with `@CollectionFormat(feign.CollectionFormat.CSV)`

See: https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/#feign-collectionformat-support