### PR TITLE
Exclude jupiter engine from acceptance tests

### DIFF
--- a/activiti-cloud-acceptance-scenarios/modeling-acceptance-tests/pom.xml
+++ b/activiti-cloud-acceptance-scenarios/modeling-acceptance-tests/pom.xml
@@ -13,6 +13,12 @@
     <dependency>
       <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-acceptance-tests-modeling</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Having both junit 4 and junit 5 in the classpath is preventing acceptance tests from being detected and launched

Ref https://github.com/Activiti/Activiti/issues/3590