### PR TITLE
Shorten PREVIEW_NAME to generate valid k8s names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,16 +96,16 @@ jobs:
           echo set BRANCH_NAME=$BRANCH_NAME
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
+      - name: Set PREVIEW_NAME env variable
+        run: |
+          PREVIEW_NAME=${BRANCH_NAME:0:28}-$GITHUB_RUN_NUMBER
+          echo set PREVIEW_NAME=$PREVIEW_NAME
+          echo "PREVIEW_NAME=$PREVIEW_NAME" >> $GITHUB_ENV
+
       - name: Set preview version
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          echo 0.0.1-$BRANCH_NAME-$GITHUB_RUN_NUMBER-SNAPSHOT > VERSION
-
-      - name: Set PREVIEW_NAMESPACE env variable
-        run: |
-          PREVIEW_NAMESPACE=$BRANCH_NAME-$GITHUB_RUN_NUMBER
-          echo set PREVIEW_NAMESPACE=$PREVIEW_NAMESPACE
-          echo "PREVIEW_NAMESPACE=$PREVIEW_NAMESPACE" >> $GITHUB_ENV
+          echo 0.0.1-$PREVIEW_NAME-SNAPSHOT > VERSION
 
       - name: Set VERSION env variable
         run: |
@@ -154,8 +154,8 @@ jobs:
           export SSO_PROTOCOL=https
           export GATEWAY_PROTOCOL=https
           export GLOBAL_GATEWAY_DOMAIN=$CLUSTER_NAME.$CLUSTER_DOMAIN
-          export GATEWAY_HOST=gateway-$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN
-          export SSO_HOST=identity-$PREVIEW_NAMESPACE.$GLOBAL_GATEWAY_DOMAIN
+          export GATEWAY_HOST=gateway-$PREVIEW_NAME.$GLOBAL_GATEWAY_DOMAIN
+          export SSO_HOST=identity-$PREVIEW_NAME.$GLOBAL_GATEWAY_DOMAIN
 
           make install
 
@@ -178,7 +178,7 @@ jobs:
             sleep 5
           done
 
-          kubectl get all -n $PREVIEW_NAMESPACE
+          kubectl get all -n $PREVIEW_NAME
 
           make test/modeling-acceptance-tests
           make test/runtime-acceptance-tests

--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,17 @@ install: release
 	echo helm $(helm version --short)
 	cd $(ACTIVITI_CLOUD_FULL_EXAMPLE_DIR) && \
 		helm dep up && \
-		helm upgrade ${PREVIEW_NAMESPACE} . \
+		helm upgrade ${PREVIEW_NAME} . \
 			--install \
 			--set global.gateway.http=false \
 			--set global.gateway.domain=${GLOBAL_GATEWAY_DOMAIN} \
-			--namespace ${PREVIEW_NAMESPACE} \
+			--namespace ${PREVIEW_NAME} \
 			--create-namespace \
 			--wait
 
 delete:
-	helm uninstall ${PREVIEW_NAMESPACE} --namespace ${PREVIEW_NAMESPACE} || echo "try to remove helm chart"
-	kubectl delete ns ${PREVIEW_NAMESPACE} || echo "try to remove namespace ${PREVIEW_NAMESPACE}"
+	helm uninstall ${PREVIEW_NAME} --namespace ${PREVIEW_NAME} || echo "try to remove helm chart"
+	kubectl delete ns ${PREVIEW_NAME} || echo "try to remove namespace ${PREVIEW_NAME}"
 
 clone-chart:
 	rm -rf $(ACTIVITI_CLOUD_FULL_CHART_CHECKOUT_DIR) && \


### PR DESCRIPTION
fixes Activiti/Activiti#3586
* renamed PREVIEW_NAMESPACE to PREVIEW_NAME as it's used for both namespace and name in helm
* use first 28 chars from branch name for PREVIEW_NAME