### PR TITLE
fix(.github): branch name for preview name is too long

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Set PREVIEW_NAME env variable
         id: set-preview-name
         run: |
-          test ${GITHUB_PR_NUMBER} && PREVIEW_NAME=pr-${GITHUB_PR_NUMBER} || PREVIEW_NAME=${BRANCH_NAME:0:28}-$GITHUB_RUN_NUMBER
+          test ${GITHUB_PR_NUMBER} && PREVIEW_NAME=pr-${GITHUB_PR_NUMBER} || PREVIEW_NAME=gh-$GITHUB_RUN_NUMBER
           echo set PREVIEW_NAME=$PREVIEW_NAME
           echo "PREVIEW_NAME=$PREVIEW_NAME" >> $GITHUB_ENV
           echo "::set-output name=preview-name::$PREVIEW_NAME"


### PR DESCRIPTION
There is an issue with Helm release on master because the release name is too long which creates resource name conflict between Keycloak and Rabbitmq