### PR TITLE
fix: Improve message event handling when there are several runtime bundles

### DIFF
--- a/activiti-cloud-acceptance-scenarios/pom.xml
+++ b/activiti-cloud-acceptance-scenarios/pom.xml
@@ -32,7 +32,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.1.705</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-461-418-SNAPSHOT</activiti-cloud.version>
     <serenity-maven-plugin.version>2.4.34</serenity-maven-plugin.version>
     <feign.version>10.7.0</feign.version>
   </properties>

--- a/activiti-cloud-dependencies/pom.xml
+++ b/activiti-cloud-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.activiti.cloud</groupId>
     <artifactId>activiti-cloud-build-parent</artifactId>
-    <version>7.1.705</version>
+    <version>0.0.1-PR-461-418-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <artifactId>activiti-cloud-dependencies-parent</artifactId>
@@ -17,7 +17,7 @@
     <java.version>1.${java.release}</java.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.1.705</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-461-418-SNAPSHOT</activiti-cloud.version>
   </properties>
   <repositories>
     <repository>

--- a/activiti-cloud-modeling/liquibase/pom.xml
+++ b/activiti-cloud-modeling/liquibase/pom.xml
@@ -14,7 +14,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.1.705</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-461-418-SNAPSHOT</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-modeling/pom.xml
+++ b/activiti-cloud-modeling/pom.xml
@@ -16,7 +16,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.1.705</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-461-418-SNAPSHOT</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-query/liquibase/pom.xml
+++ b/activiti-cloud-query/liquibase/pom.xml
@@ -15,7 +15,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.1.705</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-461-418-SNAPSHOT</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-query/pom.xml
+++ b/activiti-cloud-query/pom.xml
@@ -21,7 +21,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.1.705</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-461-418-SNAPSHOT</activiti-cloud.version>
     <start-class>org.activiti.cloud.query.QueryApplication</start-class>
   </properties>
   <dependencyManagement>

--- a/example-cloud-connector/pom.xml
+++ b/example-cloud-connector/pom.xml
@@ -19,7 +19,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.1.705</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-461-418-SNAPSHOT</activiti-cloud.version>
     <start-class>org.activiti.cloud.examples.CloudConnectorApp</start-class>
   </properties>
   <dependencyManagement>

--- a/example-runtime-bundle/pom.xml
+++ b/example-runtime-bundle/pom.xml
@@ -26,7 +26,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.1.705</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-461-418-SNAPSHOT</activiti-cloud.version>
     <docker-maven-plugin.version>0.34.1</docker-maven-plugin.version>
     <start-class>org.activiti.cloud.runtime.RuntimeBundleApplication</start-class>
   </properties>

--- a/example-runtime-bundle/starter/src/main/resources/application.properties
+++ b/example-runtime-bundle/starter/src/main/resources/application.properties
@@ -1,18 +1,5 @@
 spring.application.name=${ACT_RB_APP_NAME:rb}
 
-spring.cloud.stream.bindings.auditProducer.destination=${ACT_RB_AUDIT_PRODUCER_DEST:engineEvents}
-spring.cloud.stream.bindings.auditProducer.contentType=${ACT_RB_AUDIT_PRODUCER_CONTENT_TYPE:application/json}
-
-spring.cloud.stream.bindings.myCmdResults.destination=${ACT_RB_COMMAND_RESULTS_DEST:commandResults}
-spring.cloud.stream.bindings.myCmdResults.group=${ACT_RB_COMMAND_RESULTS_GROUP:myCmdGroup}
-spring.cloud.stream.bindings.myCmdResults.contentType=${ACT_RB_COMMAND_RESULTS_CONTENT_TYPE:application/json}
-spring.cloud.stream.bindings.myCmdProducer.destination=${ACT_RB_COMMAND_RESULTS_DEST:commandConsumer}
-spring.cloud.stream.bindings.myCmdProducer.contentType=${ACT_RB_COMMAND_RESULTS_CONTENT_TYPE:application/json}
-spring.cloud.stream.bindings.signalProducer.destination=${ACT_RB_SIGNAL_PRODUCER_DEST:signalEvent}
-spring.cloud.stream.bindings.signalProducer.contentType=${ACT_RB_SIGNAL_PRODUCER_CONTENT_TYPE:application/json}
-spring.cloud.stream.bindings.signalConsumer.destination=${ACT_RB_SIGNAL_CONSUMER_DEST:signalEvent}
-spring.cloud.stream.bindings.signalConsumer.group=${ACT_RB_SIGNAL_CONSUMER_GROUP:mySignalConsumerGroup}
-spring.cloud.stream.bindings.signalConsumer.contentType=${ACT_RB_SIGNAL_CONSUMER_CONTENT_TYPE:application/json}
 spring.jackson.serialization.fail-on-unwrapped-type-identifiers=${ACT_RB_JACKSON_FAIL_ON_UNWRAPPED_IDS:false}
 
 keycloak.auth-server-url=${ACT_KEYCLOAK_URL:http://activiti-keycloak:8180/auth}


### PR DESCRIPTION
This PR removes redundant configuration properties provided by runtime bundler starter

Depends on https://github.com/Activiti/activiti-cloud/pull/461

Part of https://github.com/Activiti/Activiti/issues/3702