### PR TITLE
Fix mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,6 @@ queue_rules:
       - status-success=test (kafka, partitioned, default-destinations)
       - status-success=test (kafka, non-partitioned, default-destinations)
       - status-success=test (kafka, partitioned, override-destinations)
-      - status-success=promote
       - label!=do-not-merge
 pull_request_rules:
   - name: queue when bot user
@@ -19,7 +18,6 @@ pull_request_rules:
       - status-success=test (kafka, partitioned, default-destinations)
       - status-success=test (kafka, non-partitioned, default-destinations)
       - status-success=test (kafka, partitioned, override-destinations)
-      - status-success=promote
       - label!=do-not-merge
     actions:
       queue:
@@ -36,7 +34,6 @@ pull_request_rules:
       - status-success=test (kafka, partitioned, default-destinations)
       - status-success=test (kafka, non-partitioned, default-destinations)
       - status-success=test (kafka, partitioned, override-destinations)
-      - status-success=promote
       - status-success=license/cla
       - label!=do-not-merge
     actions:


### PR DESCRIPTION
Pull requests skip `promote` job, so it should not be required.

Part fo Activiti/Activiti#3945