### PR TITLE
Don't delete docker tags for alpha versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -398,9 +398,9 @@ jobs:
           IS_PREVIEW: ${{ github.event_name == 'pull_request' && contains(github.head_ref, 'preview') }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-            if [ $IS_PREVIEW = true ]
+            if [ $IS_PREVIEW = true ] || [ $GITHUB_EVENT_NAME = "push" ]
             then
-                echo "Skipping delete Docker images for preview"
+                echo "Skipping delete Docker images"
             else
                 echo $VERSION > VERSION
                 echo "Delete Docker images"


### PR DESCRIPTION
Docker images generated by the main build should be kept so they can be used during the main releases to avoid rebuilding everything