### PR TITLE
Limit propagation to helm charts to develop branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -491,7 +491,7 @@ jobs:
     needs:
       - build
       - publish
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push' && github.ref_name == 'develop'
     env:
       VERSION: ${{ needs.build.outputs.version }}
       FULL_CHART_DIR: full-chart


### PR DESCRIPTION
Maintenance branches, i.e, 7.5.x should not be propagation internal releases to helm charts
