### PR TITLE
fix: Update service task status in Query to STARTED after triggering Replay on ERROR

### DIFF
--- a/activiti-cloud-acceptance-scenarios/pom.xml
+++ b/activiti-cloud-acceptance-scenarios/pom.xml
@@ -32,7 +32,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.5.0-alpha.50</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
     <serenity-maven-plugin.version>2.4.34</serenity-maven-plugin.version>
   </properties>
   <dependencyManagement>

--- a/activiti-cloud-acceptance-scenarios/pom.xml
+++ b/activiti-cloud-acceptance-scenarios/pom.xml
@@ -32,7 +32,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
+    <activiti-cloud.version>7.5.0-alpha.51</activiti-cloud.version>
     <serenity-maven-plugin.version>2.4.34</serenity-maven-plugin.version>
   </properties>
   <dependencyManagement>

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
@@ -68,8 +68,6 @@ public class ProcessInstanceServiceTasks {
     @Steps
     private ServiceTasksAdminSteps serviceTasksAdminSteps;
 
-    private ProcessInstance processInstance;
-
     @When("services are started")
     public void checkServicesStatus() {
         processRuntimeBundleSteps.checkServicesHealth();
@@ -79,7 +77,7 @@ public class ProcessInstanceServiceTasks {
 
     @When("the user starts a process with service tasks called $processName")
     public void startProcess(String processName) throws IOException, InterruptedException {
-        processInstance = processRuntimeBundleSteps.startProcess(processDefinitionKeyMatcher(processName),false);
+        ProcessInstance processInstance = processRuntimeBundleSteps.startProcess(processDefinitionKeyMatcher(processName),false);
         Serenity.setSessionVariable("processInstanceId").to(processInstance.getId());
     }
 
@@ -216,6 +214,7 @@ public class ProcessInstanceServiceTasks {
     public void verifyIntegrationContextEventsForProcess() throws Exception {
 
         String processId = Serenity.sessionVariableCalled("processInstanceId");
+        ProcessInstance processInstance = processQuerySteps.getProcessInstance(processId);
 
         await().untilAsserted(() -> {
             Collection<CloudRuntimeEvent> events = auditSteps.getEventsByProcessInstanceId(processId);
@@ -255,6 +254,7 @@ public class ProcessInstanceServiceTasks {
     public void verifyIntegrationContextErrorEventsForProcess() throws Exception {
 
         String processId = Serenity.sessionVariableCalled("processInstanceId");
+        ProcessInstance processInstance = processQuerySteps.getProcessInstance(processId);
 
         await().untilAsserted(() -> {
             Collection<CloudRuntimeEvent> events = auditSteps.getEventsByProcessInstanceId(processId);

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/java/org/activiti/cloud/qa/story/ProcessInstanceServiceTasks.java
@@ -231,22 +231,42 @@ public class ProcessInstanceServiceTasks {
                                 event -> integrationContext(event).getProcessInstanceId()
                     )
                     .containsOnly(
-                                     tuple(IntegrationEvent.IntegrationEvents.INTEGRATION_RESULT_RECEIVED,
-                                           processInstance.getProcessDefinitionId(),
-                                           processInstance.getId(),
-                                           processInstance.getProcessDefinitionKey(),
-                                           processInstance.getBusinessKey(),
-                                           processInstance.getProcessDefinitionId(),
-                                           processInstance.getId()
-                                     ),
-                                     tuple(IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED,
-                                           processInstance.getProcessDefinitionId(),
-                                           processInstance.getId(),
-                                           processInstance.getProcessDefinitionKey(),
-                                           processInstance.getBusinessKey(),
-                                           processInstance.getProcessDefinitionId(),
-                                           processInstance.getId()
-                                     ));
+                        integrationEvent(IntegrationEvent.IntegrationEvents.INTEGRATION_RESULT_RECEIVED,
+                                         processInstance),
+                        integrationEvent(IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED,
+                                         processInstance));
+        });
+    }
+
+    @Then("all integration context events are emitted for the process")
+    public void verifyAllIntegrationContextEventsForProcess() throws Exception {
+
+        String processId = Serenity.sessionVariableCalled("processInstanceId");
+        ProcessInstance processInstance = processQuerySteps.getProcessInstance(processId);
+
+        await().untilAsserted(() -> {
+            Collection<CloudRuntimeEvent> events = auditSteps.getEventsByProcessInstanceId(processId);
+
+            assertThat(events)
+                .filteredOn(CloudIntegrationEvent.class::isInstance)
+                .isNotEmpty()
+                .extracting(CloudRuntimeEvent::getEventType,
+                            CloudRuntimeEvent::getProcessDefinitionId,
+                            CloudRuntimeEvent::getProcessInstanceId,
+                            CloudRuntimeEvent::getProcessDefinitionKey,
+                            CloudRuntimeEvent::getBusinessKey,
+                            event -> integrationContext(event).getProcessDefinitionId(),
+                            event -> integrationContext(event).getProcessInstanceId()
+                )
+                .containsOnly(
+                    integrationEvent(IntegrationEvent.IntegrationEvents.INTEGRATION_RESULT_RECEIVED,
+                                     processInstance),
+                    integrationEvent(IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED,
+                                     processInstance),
+                    integrationEvent(IntegrationEvent.IntegrationEvents.INTEGRATION_ERROR_RECEIVED,
+                                     processInstance),
+                    integrationEvent(IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED,
+                                     processInstance));
         });
     }
 
@@ -271,22 +291,10 @@ public class ProcessInstanceServiceTasks {
                                 event -> integrationContext(event).getProcessInstanceId()
                     )
                     .containsOnly(
-                                     tuple(IntegrationEvent.IntegrationEvents.INTEGRATION_ERROR_RECEIVED,
-                                           processInstance.getProcessDefinitionId(),
-                                           processInstance.getId(),
-                                           processInstance.getProcessDefinitionKey(),
-                                           processInstance.getBusinessKey(),
-                                           processInstance.getProcessDefinitionId(),
-                                           processInstance.getId()
-                                     ),
-                                     tuple(IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED,
-                                           processInstance.getProcessDefinitionId(),
-                                           processInstance.getId(),
-                                           processInstance.getProcessDefinitionKey(),
-                                           processInstance.getBusinessKey(),
-                                           processInstance.getProcessDefinitionId(),
-                                           processInstance.getId()
-                                     ));
+                        integrationEvent(IntegrationEvent.IntegrationEvents.INTEGRATION_ERROR_RECEIVED,
+                                         processInstance),
+                        integrationEvent(IntegrationEvent.IntegrationEvents.INTEGRATION_REQUESTED,
+                                         processInstance));
         });
     }
 
@@ -316,5 +324,17 @@ public class ProcessInstanceServiceTasks {
             serviceTasksAdminSteps.replayServiceTask(executionId,
                                                      new ReplayServiceTaskRequest(clientId));
         });
+    }
+
+    private org.assertj.core.groups.Tuple integrationEvent(IntegrationEvent.IntegrationEvents type,
+                                                           ProcessInstance processInstance) {
+        return tuple(type,
+                     processInstance.getProcessDefinitionId(),
+                     processInstance.getId(),
+                     processInstance.getProcessDefinitionKey(),
+                     processInstance.getBusinessKey(),
+                     processInstance.getProcessDefinitionId(),
+                     processInstance.getId()
+        );
     }
 }

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -60,5 +60,7 @@ And integration error event is emitted for the process
 And the user can get list of service tasks with status of ERROR
 Then the user set the instance variable var with value replay
 And the user can replay service task execution
+And the user can get list of service tasks with status of STARTED
+And integration context events are emitted for the process
 And the user can get list of service tasks with status of COMPLETED
 And the process with service tasks is completed

--- a/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
+++ b/activiti-cloud-acceptance-scenarios/runtime-acceptance-tests/src/main/resources/stories/runtime-bundle/process-instance-service-tasks-actions.story
@@ -61,6 +61,6 @@ And the user can get list of service tasks with status of ERROR
 Then the user set the instance variable var with value replay
 And the user can replay service task execution
 And the user can get list of service tasks with status of STARTED
-And integration context events are emitted for the process
+And all integration context events are emitted for the process
 And the user can get list of service tasks with status of COMPLETED
 And the process with service tasks is completed

--- a/activiti-cloud-dependencies/pom.xml
+++ b/activiti-cloud-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.activiti.cloud</groupId>
     <artifactId>activiti-cloud-build-parent</artifactId>
-    <version>7.5.0-alpha.50</version>
+    <version>0.0.1-PR-819-2110-SNAPSHOT</version>
     <relativePath/>
   </parent>
   <artifactId>activiti-cloud-dependencies-parent</artifactId>
@@ -17,7 +17,7 @@
     <java.version>1.${java.release}</java.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.5.0-alpha.50</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
   </properties>
   <repositories>
     <repository>

--- a/activiti-cloud-dependencies/pom.xml
+++ b/activiti-cloud-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.activiti.cloud</groupId>
     <artifactId>activiti-cloud-build-parent</artifactId>
-    <version>0.0.1-PR-819-2110-SNAPSHOT</version>
+    <version>7.5.0-alpha.51</version>
     <relativePath/>
   </parent>
   <artifactId>activiti-cloud-dependencies-parent</artifactId>
@@ -17,7 +17,7 @@
     <java.version>1.${java.release}</java.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
+    <activiti-cloud.version>7.5.0-alpha.51</activiti-cloud.version>
   </properties>
   <repositories>
     <repository>

--- a/activiti-cloud-identity-adapter/pom.xml
+++ b/activiti-cloud-identity-adapter/pom.xml
@@ -15,7 +15,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.5.0-alpha.50</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-identity-adapter/pom.xml
+++ b/activiti-cloud-identity-adapter/pom.xml
@@ -15,7 +15,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
+    <activiti-cloud.version>7.5.0-alpha.51</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-modeling/liquibase/pom.xml
+++ b/activiti-cloud-modeling/liquibase/pom.xml
@@ -14,7 +14,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.5.0-alpha.50</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-modeling/liquibase/pom.xml
+++ b/activiti-cloud-modeling/liquibase/pom.xml
@@ -14,7 +14,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
+    <activiti-cloud.version>7.5.0-alpha.51</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-modeling/pom.xml
+++ b/activiti-cloud-modeling/pom.xml
@@ -15,7 +15,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.5.0-alpha.50</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-modeling/pom.xml
+++ b/activiti-cloud-modeling/pom.xml
@@ -15,7 +15,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
+    <activiti-cloud.version>7.5.0-alpha.51</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-query/liquibase/pom.xml
+++ b/activiti-cloud-query/liquibase/pom.xml
@@ -14,7 +14,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.5.0-alpha.50</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-query/liquibase/pom.xml
+++ b/activiti-cloud-query/liquibase/pom.xml
@@ -14,7 +14,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
+    <activiti-cloud.version>7.5.0-alpha.51</activiti-cloud.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/activiti-cloud-query/pom.xml
+++ b/activiti-cloud-query/pom.xml
@@ -20,7 +20,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
+    <activiti-cloud.version>7.5.0-alpha.51</activiti-cloud.version>
     <start-class>org.activiti.cloud.query.QueryApplication</start-class>
     <graphql-java.version>13.0</graphql-java.version>
   </properties>

--- a/activiti-cloud-query/pom.xml
+++ b/activiti-cloud-query/pom.xml
@@ -20,7 +20,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.5.0-alpha.50</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
     <start-class>org.activiti.cloud.query.QueryApplication</start-class>
     <graphql-java.version>13.0</graphql-java.version>
   </properties>

--- a/example-cloud-connector/pom.xml
+++ b/example-cloud-connector/pom.xml
@@ -18,7 +18,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.5.0-alpha.50</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
     <start-class>org.activiti.cloud.examples.CloudConnectorApp</start-class>
   </properties>
   <dependencyManagement>

--- a/example-cloud-connector/pom.xml
+++ b/example-cloud-connector/pom.xml
@@ -18,7 +18,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
+    <activiti-cloud.version>7.5.0-alpha.51</activiti-cloud.version>
     <start-class>org.activiti.cloud.examples.CloudConnectorApp</start-class>
   </properties>
   <dependencyManagement>

--- a/example-runtime-bundle/pom.xml
+++ b/example-runtime-bundle/pom.xml
@@ -25,7 +25,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
+    <activiti-cloud.version>7.5.0-alpha.51</activiti-cloud.version>
     <docker-maven-plugin.version>0.34.1</docker-maven-plugin.version>
     <start-class>org.activiti.cloud.runtime.RuntimeBundleApplication</start-class>
   </properties>

--- a/example-runtime-bundle/pom.xml
+++ b/example-runtime-bundle/pom.xml
@@ -25,7 +25,7 @@
     <java.release>11</java.release>
     <java.version>1.${java.release}</java.version>
     <maven.compiler.release>${java.release}</maven.compiler.release>
-    <activiti-cloud.version>7.5.0-alpha.50</activiti-cloud.version>
+    <activiti-cloud.version>0.0.1-PR-819-2110-SNAPSHOT</activiti-cloud.version>
     <docker-maven-plugin.version>0.34.1</docker-maven-plugin.version>
     <start-class>org.activiti.cloud.runtime.RuntimeBundleApplication</start-class>
   </properties>


### PR DESCRIPTION
Add acceptance test for updating service task status to STARTED after IntegrationRequestedEvent is emitted and handled by Query Service.

Depends on https://github.com/Activiti/activiti-cloud/pull/819

Part of https://github.com/Activiti/Activiti/issues/4056