### PR TITLE
Add workflow to trigger beta releases when an alpha tag is created

### DIFF
--- a/.github/workflows/trigger-beta-releases.yml
+++ b/.github/workflows/trigger-beta-releases.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    tags: ['[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+']
+
+jobs:
+  trigger-beta-release:
+    runs-on: ubuntu-latest
+    env:
+      ACT_SCRIPT_PATH: repos/scripts
+      ALPHA_VERSION: ${{ github.ref_name }}
+      ACTIVITI_SCRIPTS_BRANCH: master
+    steps:
+      - name: Checkout activiti-scripts
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.ACT_SCRIPT_PATH }}
+          repository: Activiti/activiti-scripts
+          ref: ${{ env.ACTIVITI_SCRIPTS_BRANCH }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - name: Update Activiti Cloud Application base tag
+        working-directory: ${{ env.ACT_SCRIPT_PATH }}
+        run: yq -i e '.release.baseTag.activitiCloudApplication = env(ALPHA_VERSION)' release.yaml
+
+      - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v1.15.0
+        with:
+          username: ${{ secrets.BOT_GITHUB_USERNAME }}
+          add-options: -u
+          repository-directory: ${{ env.ACT_SCRIPT_PATH }}
+          commit-message: "[Release:beta] from Activiti Cloud Application ${{ env.ALPHA_VERSION }}"
+
+      - name: Push changes
+        working-directory: ${{ env.ACT_SCRIPT_PATH }}
+        run: git push origin ${{ env.ACTIVITI_SCRIPTS_BRANCH }}

--- a/.github/workflows/trigger-beta-releases.yml
+++ b/.github/workflows/trigger-beta-releases.yml
@@ -18,14 +18,14 @@ jobs:
           ref: ${{ env.ACTIVITI_SCRIPTS_BRANCH }}
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
-      - uses: Alfresco/alfresco-build-tools/.github/actions/update-project-base-tag@aae-8916-beta-tags-update-base-tag
+      - uses: Alfresco/alfresco-build-tools/.github/actions/update-project-base-tag@v.16.0
         with:
           release-descriptor: ${{ env.ACT_SCRIPT_PATH }}/release.yaml
           project: activitiCloudApplication
           tag: ${{ env.ALPHA_VERSION }}
 
 
-      - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v1.15.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v1.16.0
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}
           add-options: -u

--- a/.github/workflows/trigger-beta-releases.yml
+++ b/.github/workflows/trigger-beta-releases.yml
@@ -18,9 +18,12 @@ jobs:
           ref: ${{ env.ACTIVITI_SCRIPTS_BRANCH }}
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
-      - name: Update Activiti Cloud Application base tag
-        working-directory: ${{ env.ACT_SCRIPT_PATH }}
-        run: yq -i e '.release.baseTag.activitiCloudApplication = env(ALPHA_VERSION)' release.yaml
+      - uses: Alfresco/alfresco-build-tools/.github/actions/update-project-base-tag@aae-8916-beta-tags-update-base-tag
+        with:
+          release-descriptor: ${{ env.ACT_SCRIPT_PATH }}/release.yaml
+          project: activitiCloudApplication
+          tag: ${{ env.ALPHA_VERSION }}
+
 
       - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v1.15.0
         with:

--- a/.github/workflows/trigger-beta-releases.yml
+++ b/.github/workflows/trigger-beta-releases.yml
@@ -23,8 +23,6 @@ jobs:
           release-descriptor: ${{ env.ACT_SCRIPT_PATH }}/release.yaml
           project: activitiCloudApplication
           tag: ${{ env.ALPHA_VERSION }}
-
-
       - uses: Alfresco/alfresco-build-tools/.github/actions/git-commit-changes@v1.16.0
         with:
           username: ${{ secrets.BOT_GITHUB_USERNAME }}


### PR DESCRIPTION
When an alpha release is created on this terminal project, a workflow creates a commit in `activiti-scripts` to trigger the creation of beta releases.

Ref: https://github.com/Activiti/Activiti/issues/4081