### PR TITLE
Use custom PAT to create tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -413,6 +413,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Setup Java JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/trigger-beta-releases.yml
+++ b/.github/workflows/trigger-beta-releases.yml
@@ -1,3 +1,5 @@
+name: Trigger beta releases
+
 on:
   push:
     tags: ['[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+']


### PR DESCRIPTION
Tags created using the default GITHUB_TOKEN will not trigger workflows, so  should be used instead.
Ref https://github.com/Activiti/Activiti/issues/4081
