### PR TITLE
AAE-10865: remove GITHUB_RUN_NUMBER from docker images names for PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Set preview version
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          echo 0.0.1-$PREVIEW_NAME-$GITHUB_RUN_NUMBER-SNAPSHOT > VERSION
+          echo 0.0.1-$PREVIEW_NAME-SNAPSHOT > VERSION
 
       - name: Set VERSION env variable
         id: set-version

--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Set preview version
         run: |
-          echo 0.0.1-$PREVIEW_NAME-$GITHUB_RUN_NUMBER-SNAPSHOT > VERSION
+          echo 0.0.1-$PREVIEW_NAME-SNAPSHOT > VERSION
 
       - name: Delete Docker images
         env:


### PR DESCRIPTION
Fixes https://github.com/Activiti/Activiti/issues/4146

@erdemedeiros: the run number is still included in the preview name when the main build is run on the `develop` branch, but in this case the `pr-closed` workflow will not be run anyway.
Also I did not refine the curl calls to avoid failing the job when the images do not exist: if they do not exist the previous status was not good anyway and the docker images were not pushed, so I guess it's ok.