### PR TITLE
AAE-10092: avoid cancel when running remote tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,6 @@ on:
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name || github.run_id }}
-  cancel-in-progress: true
-
 env:
   CLUSTER_NAME: activiti-test
   CLUSTER_DOMAIN: envalfresco.com


### PR DESCRIPTION
Related to https://github.com/Activiti/Activiti/issues/4032

This should allow proper cleanup of remote envs and docker images (that might be skipped on automated cancel of jobs)