### PR TITLE
Fix example runtime bundle Dockerfile - accept ttf-mscorefonts-installer eula

### DIFF
--- a/example-runtime-bundle/Dockerfile
+++ b/example-runtime-bundle/Dockerfile
@@ -10,6 +10,7 @@
 
 FROM adoptopenjdk/openjdk11:jdk-11.0.2.9-slim
 RUN  apt update
+RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
 RUN apt -y install ttf-mscorefonts-installer fontconfig
 RUN fc-cache -f -v
 ENV PORT 8080


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4220

The docker image build fails when the "TrueType core fonts for the Web EULA" is not accepted automatically. This change presets the approval.