### PR TITLE
Add ConsumerConnector interface

### DIFF
--- a/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/ExampleConnector.java
+++ b/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/ExampleConnector.java
@@ -25,8 +25,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
-import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.activiti.cloud.connectors.starter.channels.IntegrationResultSender;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
 import org.activiti.cloud.connectors.starter.model.IntegrationResultBuilder;
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
 
 @ConnectorBinding(input = ExampleConnectorChannels.EXAMPLE_CONNECTOR_CONSUMER, condition = "")
 @Component(ExampleConnectorChannels.EXAMPLE_CONNECTOR_CONSUMER + "Connector")
-public class ExampleConnector implements Connector<IntegrationRequest, Void> {
+public class ExampleConnector implements ConsumerConnector<IntegrationRequest> {
 
     private final Logger logger = LoggerFactory.getLogger(ExampleConnector.class);
 
@@ -67,7 +67,7 @@ public class ExampleConnector implements Connector<IntegrationRequest, Void> {
     }
 
     @Override
-    public Void apply(IntegrationRequest event) {
+    public void accept(IntegrationRequest event) {
         logger.info(append("service-name", appName), ">>> In example-cloud-connector");
 
         String var1 =
@@ -108,7 +108,6 @@ public class ExampleConnector implements Connector<IntegrationRequest, Void> {
             .buildMessage();
 
         integrationResultSender.send(message);
-        return null;
     }
 
     private void processJsonVar(Object jsonVar, Map<String, Object> results) {

--- a/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/HeadersConnector.java
+++ b/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/HeadersConnector.java
@@ -19,8 +19,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
-import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.activiti.cloud.connectors.starter.channels.IntegrationResultSender;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
 import org.activiti.cloud.connectors.starter.model.IntegrationResultBuilder;
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
     outputHeader = ""
 )
 @Component(HeadersConnectorChannels.HEADERS_CONNECTOR_CONSUMER + "Connector")
-public class HeadersConnector implements Connector<Message<IntegrationRequest>, Void> {
+public class HeadersConnector implements ConsumerConnector<Message<IntegrationRequest>> {
 
     private final IntegrationResultSender integrationResultSender;
     private final ConnectorProperties connectorProperties;
@@ -47,7 +47,7 @@ public class HeadersConnector implements Connector<Message<IntegrationRequest>, 
     }
 
     @Override
-    public Void apply(Message<IntegrationRequest> integrationRequestMessage) {
+    public void accept(Message<IntegrationRequest> integrationRequestMessage) {
         MessageHeaders headers = integrationRequestMessage.getHeaders();
         IntegrationRequest integrationRequest = integrationRequestMessage.getPayload();
 
@@ -63,6 +63,5 @@ public class HeadersConnector implements Connector<Message<IntegrationRequest>, 
             .buildMessage();
 
         integrationResultSender.send(message);
-        return null;
     }
 }

--- a/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/MoviesDescriptionConnector.java
+++ b/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/MoviesDescriptionConnector.java
@@ -18,8 +18,8 @@ package org.activiti.cloud.examples.connectors;
 import java.util.Map;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
-import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.activiti.cloud.connectors.starter.channels.IntegrationResultSender;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
 import org.activiti.cloud.connectors.starter.model.IntegrationResultBuilder;
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
     outputHeader = ""
 )
 @Component(MoviesDescriptionConnectorChannels.MOVIES_DESCRIPTION_CONSUMER + "Connector")
-public class MoviesDescriptionConnector implements Connector<IntegrationRequest, Void> {
+public class MoviesDescriptionConnector implements ConsumerConnector<IntegrationRequest> {
 
     private Logger logger = LoggerFactory.getLogger(MoviesDescriptionConnector.class);
 
@@ -49,7 +49,7 @@ public class MoviesDescriptionConnector implements Connector<IntegrationRequest,
     }
 
     @Override
-    public Void apply(IntegrationRequest integrationRequest) {
+    public void accept(IntegrationRequest integrationRequest) {
         IntegrationContext integrationContext = integrationRequest.getIntegrationContext();
         Map<String, Object> inBoundVariables = integrationContext.getInBoundVariables();
         logger.info(">>inbound: " + inBoundVariables);
@@ -61,6 +61,5 @@ public class MoviesDescriptionConnector implements Connector<IntegrationRequest,
         integrationResultSender.send(
             IntegrationResultBuilder.resultFor(integrationRequest, connectorProperties).buildMessage()
         );
-        return null;
     }
 }

--- a/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/MultiInstanceConnector.java
+++ b/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/MultiInstanceConnector.java
@@ -21,8 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
-import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.activiti.cloud.common.messaging.functional.InputBinding;
 import org.activiti.cloud.connectors.starter.channels.IntegrationResultSender;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
 
 @ConnectorBinding(input = Channels.CHANNEL, condition = "", outputHeader = "")
 @Component(Channels.CHANNEL + "Connector")
-public class MultiInstanceConnector implements Connector<IntegrationRequest, Void> {
+public class MultiInstanceConnector implements ConsumerConnector<IntegrationRequest> {
 
     private final IntegrationResultSender integrationResultSender;
     private final ConnectorProperties connectorProperties;
@@ -61,7 +61,7 @@ public class MultiInstanceConnector implements Connector<IntegrationRequest, Voi
     }
 
     @Override
-    public Void apply(IntegrationRequest integrationRequest) {
+    public void accept(IntegrationRequest integrationRequest) {
         Integer instanceCount = getVariableValue(integrationRequest.getIntegrationContext(), "instanceCount");
         if (instanceCount == counter.get()) {
             counter.set(0);
@@ -75,7 +75,6 @@ public class MultiInstanceConnector implements Connector<IntegrationRequest, Voi
             .buildMessage();
 
         integrationResultSender.send(message);
-        return null;
     }
 
     @SuppressWarnings("unchecked")

--- a/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/RestConnector.java
+++ b/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/RestConnector.java
@@ -19,8 +19,8 @@ import java.util.HashMap;
 import java.util.Map;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
-import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.activiti.cloud.common.messaging.functional.InputBinding;
 import org.activiti.cloud.connectors.starter.channels.IntegrationResultSender;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
 
 @ConnectorBinding(input = RestConnector.Channels.POST, condition = "", outputHeader = "")
 @Component
-public class RestConnector implements Connector<IntegrationRequest, Void> {
+public class RestConnector implements ConsumerConnector<IntegrationRequest> {
 
     private final IntegrationResultSender integrationResultSender;
     private final ConnectorProperties connectorProperties;
@@ -52,7 +52,7 @@ public class RestConnector implements Connector<IntegrationRequest, Void> {
     }
 
     @Override
-    public Void apply(IntegrationRequest integrationRequest) {
+    public void accept(IntegrationRequest integrationRequest) {
         Map<String, Object> result = new HashMap<>();
 
         result.put("restStatus", 201);
@@ -63,6 +63,5 @@ public class RestConnector implements Connector<IntegrationRequest, Void> {
             .buildMessage();
 
         integrationResultSender.send(message);
-        return null;
     }
 }

--- a/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/TestBpmnErrorConnector.java
+++ b/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/TestBpmnErrorConnector.java
@@ -18,8 +18,8 @@ package org.activiti.cloud.examples.connectors;
 
 import org.activiti.cloud.api.process.model.CloudBpmnError;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
-import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.activiti.cloud.common.messaging.functional.InputBinding;
 import org.activiti.cloud.connectors.starter.channels.IntegrationErrorSender;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 
 @ConnectorBinding(input = Channels.CHANNEL, condition = "", outputHeader = "")
 @Component(Channels.CHANNEL + "Connector")
-public class TestBpmnErrorConnector implements Connector<IntegrationRequest, Void> {
+public class TestBpmnErrorConnector implements ConsumerConnector<IntegrationRequest> {
 
     private IntegrationErrorSender integrationErrorSender;
     private ConnectorProperties connectorProperties;
@@ -54,11 +54,10 @@ public class TestBpmnErrorConnector implements Connector<IntegrationRequest, Voi
     }
 
     @Override
-    public Void apply(IntegrationRequest integrationRequest) {
+    public void accept(IntegrationRequest integrationRequest) {
         CloudBpmnError bpmnError = new CloudBpmnError("CLOUD_BPMN_ERROR");
         integrationErrorSender.send(
             IntegrationErrorBuilder.errorFor(integrationRequest, connectorProperties, bpmnError).buildMessage()
         );
-        return null;
     }
 }

--- a/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/TestErrorConnector.java
+++ b/example-cloud-connector/starter/src/main/java/org/activiti/cloud/examples/connectors/TestErrorConnector.java
@@ -19,8 +19,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
 import org.activiti.cloud.api.process.model.IntegrationResult;
-import org.activiti.cloud.common.messaging.functional.Connector;
 import org.activiti.cloud.common.messaging.functional.ConnectorBinding;
+import org.activiti.cloud.common.messaging.functional.ConsumerConnector;
 import org.activiti.cloud.common.messaging.functional.InputBinding;
 import org.activiti.cloud.connectors.starter.channels.IntegrationResultSender;
 import org.activiti.cloud.connectors.starter.configuration.ConnectorProperties;
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 
 @ConnectorBinding(input = Channels.CHANNEL, condition = "", outputHeader = "")
 @Component(Channels.CHANNEL + "Connector")
-public class TestErrorConnector implements Connector<IntegrationRequest, Void> {
+public class TestErrorConnector implements ConsumerConnector<IntegrationRequest> {
 
     private static final Logger logger = LoggerFactory.getLogger(TestErrorConnector.class);
     private final IntegrationResultSender integrationResultSender;
@@ -61,7 +61,7 @@ public class TestErrorConnector implements Connector<IntegrationRequest, Void> {
     }
 
     @Override
-    public Void apply(IntegrationRequest integrationRequest) {
+    public void accept(IntegrationRequest integrationRequest) {
         String var = integrationRequest.getIntegrationContext().getInBoundVariable("var");
         if (!"replay".equals(var)) {
             throw new RuntimeException("TestErrorConnector");
@@ -83,6 +83,5 @@ public class TestErrorConnector implements Connector<IntegrationRequest, Void> {
         } catch (InterruptedException e) {
             throw new IllegalStateException(e);
         }
-        return null;
     }
 }


### PR DESCRIPTION
This PR migrates the existing `Connector` that has `Void` response to `ConsumerConnector` interface introduced in Activiti/activiti-cloud#990